### PR TITLE
PartII Redaction File Reference Fix

### DIFF
--- a/config/ppmBsm.properties
+++ b/config/ppmBsm.properties
@@ -10,6 +10,9 @@ privacy.redaction.id.value=FFFFFFFF
 privacy.redaction.id.inclusions=ON
 privacy.redaction.id.included=BEA10000,BEA10001
 
+# Configuration details for partII redaction
+privacy.redaction.partII=OFF
+
 # Configuration details for geofencing.
 privacy.filter.geofence=ON
 privacy.filter.geofence.mapfile=/ppm_data/I_80.edges

--- a/config/ppmTim.properties
+++ b/config/ppmTim.properties
@@ -10,6 +10,9 @@ privacy.redaction.id.value=FFFFFFFF
 privacy.redaction.id.inclusions=OFF
 privacy.redaction.id.included=BEA10000,BEA10001
 
+# Configuration details for partII redaction
+privacy.redaction.partII=OFF
+
 # Configuration details for geofencing.
 privacy.filter.geofence=OFF
 privacy.filter.geofence.mapfile=/ppm_data/I_80.edges

--- a/src/redaction-properties/RedactionPropertiesManager.cpp
+++ b/src/redaction-properties/RedactionPropertiesManager.cpp
@@ -16,7 +16,7 @@ class RedactionPropertiesManager {
          */
         RedactionPropertiesManager() {
             debug = false;
-            loadFields("/workspaces/jpo-cvdp/fieldsToRedact.txt"); // load fields upon construction
+            loadFields("/ppm_data/fieldsToRedact.txt"); // load fields upon construction
         }
 
         /**


### PR DESCRIPTION
# Description
The fieldsToRedact.txt file will now be pulled from the ppm_data directory on containers running the PPM image. This is where files needed during runtime are usually pulled from.

## Notes
- The PPM was previously attempting to pull this file from a directory that is not created or mounted to containers running the PPM image.
- The privacy.redaction.partII option has been added to the base config files for the project.