### PR TITLE
Removed relative paths from header imports in src files.

### DIFF
--- a/src/bsm.cpp
+++ b/src/bsm.cpp
@@ -1,4 +1,4 @@
-#include "../include/bsm.hpp"
+#include "bsm.hpp"
 
 BSM::BSM() :
     geo::Point{90.0, 180.0},

--- a/src/bsmHandler.cpp
+++ b/src/bsmHandler.cpp
@@ -36,7 +36,7 @@
 #include "cvlib.hpp"
 #include "bsmHandler.hpp"
 #include "spdlog/spdlog.h"
-#include "../../include/general-redaction/redactionPropertiesManager.hpp"
+#include "redactionPropertiesManager.hpp"
 
 BSMHandler::ResultStringMap BSMHandler::result_string_map{
             { ResultStatus::SUCCESS, "success" },

--- a/src/general-redaction/rapidjsonRedactor.cpp
+++ b/src/general-redaction/rapidjsonRedactor.cpp
@@ -1,4 +1,4 @@
-#include "../../include/general-redaction/rapidjsonRedactor.hpp"
+#include "rapidjsonRedactor.hpp"
 
 bool RapidjsonRedactor::redactAllInstancesOfMemberByName(rapidjson::Value &value, std::string member) {
     if (value.IsObject()) {

--- a/src/general-redaction/redactionPropertiesManager.cpp
+++ b/src/general-redaction/redactionPropertiesManager.cpp
@@ -1,4 +1,4 @@
-#include "../../include/general-redaction/redactionPropertiesManager.hpp"
+#include "redactionPropertiesManager.hpp"
 
 /**
  * @brief Construct a new Redaction Properties Manager object with a default path. Upon instantiation, fields are loaded from a file.

--- a/src/idRedactor.cpp
+++ b/src/idRedactor.cpp
@@ -1,4 +1,4 @@
-#include "../include/idRedactor.hpp"
+#include "idRedactor.hpp"
 
 IdRedactor::IdRedactor() :
     inclusion_set_{},

--- a/src/kafka_consumer.cpp
+++ b/src/kafka_consumer.cpp
@@ -67,8 +67,8 @@
 #include <unistd.h>
 #endif
 
-#include "../include/bsmHandler.hpp"
-#include "../include/ppmLogger.hpp"
+#include "bsmHandler.hpp"
+#include "ppmLogger.hpp"
 #include "cvlib.hpp"
 
 #include <sstream>

--- a/src/ppm.cpp
+++ b/src/ppm.cpp
@@ -49,7 +49,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../include/ppm.hpp"
+#include "ppm.hpp"
 #include "spdlog/spdlog.h"
 #include <csignal>
 #include <chrono>

--- a/src/ppmLogger.cpp
+++ b/src/ppmLogger.cpp
@@ -1,4 +1,4 @@
-#include "../../include/ppmLogger.hpp"
+#include "ppmLogger.hpp"
 
 PpmLogger::PpmLogger(std::string ilogname, std::string elogname) {
     // pull in the file & console flags from the environment

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -1,6 +1,6 @@
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
-#include "../../include/general-redaction/redactionPropertiesManager.hpp"
+#include "redactionPropertiesManager.hpp"
 
 // NOTE: The test file OPERAND is a <test-spec> (see github.com/philsquared/Catch/blob/master/docs/command-line.md) 
 // <test-spec> is defined as below.

--- a/src/velocityFilter.cpp
+++ b/src/velocityFilter.cpp
@@ -1,4 +1,4 @@
-#include "../include/velocityFilter.hpp"
+#include "velocityFilter.hpp"
 
 VelocityFilter::VelocityFilter() :
     min_{kDefaultMinVelocity},


### PR DESCRIPTION
## Purpose
Upon [request](https://github.com/usdot-jpo-ode/jpo-cvdp/pull/18#discussion_r1101834257), the relative paths have been removed from header imports in our source files since the header files are listed in the CMakeLists.txt file rendering the use of relative paths unnecessary.

## Affected Files
- src/bsm.cpp
- src/general-redaction/rapidjsonRedactor.cpp
- src/general-redaction/redactionPropertiesManager.cpp
- src/idRedactor.cpp
- src/kafka_consumer.cpp
- src/ppm.cpp
- src/ppmLogger.cpp
- src/tests.cpp
- src/velocityFilter.cpp

## Testing
These changes have been tested in our dev cluster. The project compiles and logs to the console when running as expected.