### PR TITLE
Removed remaining ilog & elog references.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,11 +71,11 @@ Logging configuration is controlled through the command line, not through the co
 
 - `-i` : The log file's name.
 
-- `-v` : The minimum level of message to write to the information log. From lowest to highest, the message levels are `off`, `trace`, `debug`, `info`,
+- `-v` : The minimum level of message to write to the log. From lowest to highest, the message levels are `off`, `trace`, `debug`, `info`,
          `warning`, `error`, `critical`. As an example, if you specify `info` then all messages that are `info, warning, error, or critical` will be written to
          the log.
 
-The information log will write the configuration it will use as `info` messages when it starts. The information log also record the disposition of the
+The log will write the configuration it will use as `info` messages when it starts. The log also records the disposition of the
 messages it receives. In the example below, the first BSM was retained, or passed on; the second message was suppressed because the vehicle's velocity
 was outside of the thresholds. The information in the parenthesis is the ID, secMark, lat, lon, speed from the BSM. All log messages are preceded
 with a date and time stamp and the level of the log message.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,8 +16,7 @@ line options override parameters specified in the configuration file.** The foll
 
 ```bash
 -h | --help : print out all the command line options.
--e | --elog : Error log file name.
--i | --ilog : Information log file name.
+-i | --log : Log file name.
 -R | --log-rm : Remove specified/default log files if they exist.
 -D | --log-dir : Directory for the log files.
 -v | --log-level : The info log level [trace,debug,info,warning,error,critical,off]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,8 +61,8 @@ the data to different "filtered" topics.
 # PPM Logging
 
 PPM operations are optionally logged to the console or a file.  The file is a rotating log file, i.e., a set number of log files will
-be used to record the PPM's information. By default, the file is located in the home directory of the machine running the PPM and the file is 
-named `log` and  The maximum size of a `log` files is 5MB and 5 files are rotated.
+be used to record the PPM's information. By default, the file is in a `logs` directory from where the ACM is launched and the file is
+named `log`. When using `ppm_no_map.sh`, the file will be in the ~/logs/ directory.The maximum size of a `log` file is 5MB and 5 files are rotated.
 Logging configuration is controlled through the command line, not through the configuration file. The following operation are available:
 
 - `-R` : When the PPM starts remove any log files having either the default or user specified names; otherwise, new log entries will be appended to existing files.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,18 +60,16 @@ the data to different "filtered" topics.
 
 # PPM Logging
 
-PPM operations are logged to two files: an information log and an error log.  The files are rotating log files, i.e., a set number of log files will
-be used to record the PPM's information. By default, these files are located in a `logs` directory from where the PPM is launched and the files are
-named `log.info` and `log.error`. The maximum size of a `log.info` files is 5MB and 5 files are rotated. The maximum size of a `log.error` file is 2MB
-and 2 files are rotated. Logging configuration is controlled through the command line, not through the configuration file. The following operation are available:
+PPM operations are optionally logged to the console or a file.  The file is a rotating log file, i.e., a set number of log files will
+be used to record the PPM's information. By default, the file is located in the home directory of the machine running the PPM and the file is 
+named `log` and  The maximum size of a `log` files is 5MB and 5 files are rotated.
+Logging configuration is controlled through the command line, not through the configuration file. The following operation are available:
 
 - `-R` : When the PPM starts remove any log files having either the default or user specified names; otherwise, new log entries will be appended to existing files.
 
 - `-D` : The directory where the log files should be written. This can be relative or absolute. If the directory does not exist, it will be created.
 
-- `-e` : The error log file's name.
-
-- `-i` : The information log file's name.
+- `-i` : The log file's name.
 
 - `-v` : The minimum level of message to write to the information log. From lowest to highest, the message levels are `off`, `trace`, `debug`, `info`,
          `warning`, `error`, `critical`. As an example, if you specify `info` then all messages that are `info, warning, error, or critical` will be written to

--- a/src/ppm.cpp
+++ b/src/ppm.cpp
@@ -729,7 +729,7 @@ bool PPM::make_loggers( bool remove_files )
         }
     }
     
-    // ilog check for user-defined file locations and names.
+    // log check for user-defined file locations and names.
     if (getOption('i').hasArg()) {
         // replace default.
         logname = string_utilities::basename<std::string>(getOption('i').argument());
@@ -859,8 +859,7 @@ int main( int argc, char* argv[] )
     ppm.addOption( 'v', "log-level", "The info log level [trace,debug,info,warning,error,critical,off]", true );
     ppm.addOption( 'D', "log-dir", "Directory for the log files.", true );
     ppm.addOption( 'R', "log-rm", "Remove specified/default log files if they exist.", false );
-    ppm.addOption( 'i', "ilog", "Information log file name.", true );
-    ppm.addOption( 'e', "elog", "Error log file name.", true );
+    ppm.addOption( 'i', "log", "Log file name.", true );
     ppm.addOption( 'h', "help", "print out some help" );
 
     if (!ppm.parseArgs(argc, argv)) {

--- a/src/ppmLogger.cpp
+++ b/src/ppmLogger.cpp
@@ -4,7 +4,7 @@ PpmLogger::PpmLogger(std::string logname) {
     // pull in the file & console flags from the environment
     initializeFlagValuesFromEnvironment();
     
-    // setup information logger.
+    // setup logger.
     std::vector<spdlog::sink_ptr> sinks;
     if (logToFileFlag) {
         sinks.push_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>(logname, LOG_SIZE, LOG_NUM));
@@ -12,7 +12,7 @@ PpmLogger::PpmLogger(std::string logname) {
     if (logToConsoleFlag) {
         sinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_mt>());
     }
-    setLogger(std::make_shared<spdlog::logger>("ilog", begin(sinks), end(sinks)));
+    setLogger(std::make_shared<spdlog::logger>("log", begin(sinks), end(sinks)));
     set_level( loglevel );
     set_pattern("[%C%m%d %H:%M:%S.%f] [%l] %v");
 }


### PR DESCRIPTION
There were a few spots that still had references to information-specific or error-specific loggers. These references have been removed or modified.