### PR TITLE
Use Confluent's Librdkafka Package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ USER root
 WORKDIR /cvdi-stream
 
 # Add build tools.
-RUN apt-get update && apt-get install -y g++
+RUN apt-get update && apt-get install -y software-properties-common wget git make gcc-7 g++-7 gcc-7-base && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 100
 
 # Install cmake.
 RUN apt install -y libprotobuf-dev protobuf-compiler

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,13 @@ RUN apt install -y libprotobuf-dev protobuf-compiler
 RUN apt install -y cmake
 
 # Install librdkafka.
-RUN apt-get install -y libsasl2-dev libsasl2-modules libssl-dev librdkafka-dev
+RUN apt-get install -y sudo
+RUN wget -qO - https://packages.confluent.io/deb/7.3/archive.key | sudo apt-key add -
+RUN add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/7.3 stable main"
+RUN add-apt-repository "deb https://packages.confluent.io/clients/deb $(lsb_release -cs) main"
+RUN apt update
+RUN apt-get install -y libsasl2-modules libsasl2-modules-gssapi-mit libsasl2-dev libssl-dev 
+RUN apt install -y librdkafka-dev
 
 # add the source and build files
 ADD CMakeLists.txt /cvdi-stream

--- a/Dockerfile-nsv
+++ b/Dockerfile-nsv
@@ -13,7 +13,13 @@ RUN apt install -y libprotobuf-dev protobuf-compiler
 RUN apt install -y cmake
 
 # Install librdkafka.
-RUN apt-get install -y libsasl2-dev libsasl2-modules libssl-dev librdkafka-dev
+RUN apt-get install -y sudo
+RUN wget -qO - https://packages.confluent.io/deb/7.3/archive.key | sudo apt-key add -
+RUN add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/7.3 stable main"
+RUN add-apt-repository "deb https://packages.confluent.io/clients/deb $(lsb_release -cs) main"
+RUN apt update
+RUN apt-get install -y libsasl2-modules libsasl2-modules-gssapi-mit libsasl2-dev libssl-dev 
+RUN apt install -y librdkafka-dev
 
 # add the source and build files
 ADD CMakeLists.txt /cvdi-stream

--- a/Dockerfile-nsv
+++ b/Dockerfile-nsv
@@ -6,7 +6,7 @@ ARG PPM_MAP_FILE
 WORKDIR /cvdi-stream
 
 # Add build tools.
-RUN apt-get update && apt-get install -y g++
+RUN apt-get update && apt-get install -y software-properties-common wget git make gcc-7 g++-7 gcc-7-base && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 100
 
 # Install cmake.
 RUN apt install -y libprotobuf-dev protobuf-compiler

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -4,7 +4,7 @@ USER root
 WORKDIR /cvdi-stream
 
 # Add build tools.
-RUN apt-get update && apt-get install -y g++
+RUN apt-get update && apt-get install -y software-properties-common wget git make gcc-7 g++-7 gcc-7-base && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 100
 
 # Install cmake.
 RUN apt install -y libprotobuf-dev protobuf-compiler

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -11,7 +11,13 @@ RUN apt install -y libprotobuf-dev protobuf-compiler
 RUN apt install -y cmake
 
 # Install librdkafka.
-RUN apt-get install -y libsasl2-dev libsasl2-modules libssl-dev librdkafka-dev
+RUN apt-get install -y sudo
+RUN wget -qO - https://packages.confluent.io/deb/7.3/archive.key | sudo apt-key add -
+RUN add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/7.3 stable main"
+RUN add-apt-repository "deb https://packages.confluent.io/clients/deb $(lsb_release -cs) main"
+RUN apt update
+RUN apt-get install -y libsasl2-modules libsasl2-modules-gssapi-mit libsasl2-dev libssl-dev 
+RUN apt install -y librdkafka-dev
 
 # add the source and build files
 ADD CMakeLists.txt /cvdi-stream


### PR DESCRIPTION

## Changes
Awhile ago we switched over to using Confluent's librdkafka package in the ACM since it was more up to date than the default package provided by ubuntu. These changes make the same switch for the PPM.

## Motivation
Our PPM deployments were disconnecting from kafka intermittently. Using Confluent's librdkafka package seems to resolve this.

## Testing
This has been tested in our dev & test clusters.