### PR TITLE
Modifying dockerfiles & .devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,13 +19,6 @@
 		"ms-vscode.cmake-tools"
 	],
 
-	"features": {
-		"docker-from-docker": {
-			"version": "latest",
-			"moby": true
-		}
-	},
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,5 @@ RUN export LD_LIBRARY_PATH=/usr/local/lib && mkdir /cvdi-stream-build && cd /cvd
 ADD ./docker-test /cvdi-stream/docker-test
 
 # Run the tool.
-RUN chmod 7777 /cvdi-stream/docker-test/ppm_no_map.sh
+RUN chmod 777 /cvdi-stream/docker-test/ppm_no_map.sh
 CMD ["/cvdi-stream/docker-test/ppm_no_map.sh"]

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -34,5 +34,5 @@ RUN export LD_LIBRARY_PATH=/usr/local/lib && mkdir /cvdi-stream-build && cd /cvd
 ADD ./docker-test /cvdi-stream/docker-test
 
 # Run the tool.
-RUN chmod 7777 /cvdi-stream/docker-test/ppm_no_map.sh
+RUN chmod 777 /cvdi-stream/docker-test/ppm_no_map.sh
 CMD ["/cvdi-stream/docker-test/ppm_no_map.sh"]


### PR DESCRIPTION
## Changes
- The 'docker-from-docker' feature has been removed from the .devcontainer specification.
- Instances of 'chmod 7777' in dockerfiles have been replaced with 'chmod 777'.

## Testing
The dev container has been verified to start up successfully, and the PPM is still able to start with the chmod change.

## PR Comments
These changes address the following USDOT PR comments:
- https://github.com/usdot-jpo-ode/jpo-cvdp/pull/31#discussion_r1369058051
- https://github.com/usdot-jpo-ode/jpo-cvdp/pull/31#discussion_r1369073672