### PR TITLE
Script Modification - Timeout for PPM Readiness

### DIFF
--- a/test-scripts/standalone.sh
+++ b/test-scripts/standalone.sh
@@ -42,6 +42,11 @@ startPPMContainer() {
     while [ $(docker logs $PPM_CONTAINER_NAME | wc -l) -lt 100 ]; do
         sleep 1
         secondsWaited=$((secondsWaited+1))
+
+        if [ $secondsWaited -gt 30 ]; then
+            echo "30 seconds have passed. Container should be ready. Continuing."
+            break
+        fi
     done
     echo "$PPM_CONTAINER_NAME is ready after $secondsWaited seconds"
 

--- a/test-scripts/standalone_multi.sh
+++ b/test-scripts/standalone_multi.sh
@@ -42,6 +42,11 @@ startPPMContainer() {
     while [ $(docker logs $PPM_CONTAINER_NAME | wc -l) -lt 100 ]; do
         sleep 1
         secondsWaited=$((secondsWaited+1))
+
+        if [ $secondsWaited -gt 30 ]; then
+            echo "30 seconds have passed. Container should be ready. Continuing."
+            break
+        fi
     done
     echo "$PPM_CONTAINER_NAME is ready after $secondsWaited seconds"
 


### PR DESCRIPTION
## Changes
Previously, the `standalone_sh` and `standalone_multi.sh` scripts relied solely on the number of logs as a measure to check for PPM container readiness. An additional timeout check has been added to these scripts to prevent stalling in the case of logging being disabled.