### PR TITLE
Direct PPM_LOG_LEVEL Access and Stalling Prevention

### DIFF
--- a/docker-test/ppm_no_map.sh
+++ b/docker-test/ppm_no_map.sh
@@ -3,4 +3,4 @@ export LD_LIBRARY_PATH=/usr/local/lib
 
 # Start the DI tool.
 
-/cvdi-stream-build/ppm -c /ppm_data/${PPM_CONFIG_FILE} -b ${DOCKER_HOST_IP}:9092 -v ${PPM_LOG_LEVEL} -D ~/logs/
+/cvdi-stream-build/ppm -c /ppm_data/${PPM_CONFIG_FILE} -b ${DOCKER_HOST_IP}:9092 -D ~/logs/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,6 @@ line options override parameters specified in the configuration file.** The foll
 -i | --log : Log file name.
 -R | --log-rm : Remove specified/default log files if they exist.
 -D | --log-dir : Directory for the log files.
--v | --log-level : The info log level [trace,debug,info,warning,error,critical,off]
 -t | --produce-topic : the name of the topic where filtered messages are published.
 -p | --partition : the partition from which to consume raw messages.
 -C | --config-check : Check whether the configuration will work and output all the settings.

--- a/include/ppmLogger.hpp
+++ b/include/ppmLogger.hpp
@@ -38,9 +38,11 @@ class PpmLogger {
 
         void setLogger(std::shared_ptr<spdlog::logger> spdlog_logger);
         void initializeFlagValuesFromEnvironment();
+        void setLogLevelFromEnvironment();
         const char* getEnvironmentVariable(std::string var);
         std::string toLowercase(std::string str);
         bool convertStringToBool(std::string str);
+        std::string getCurrentLogLevelAsString();
 };
 
 #endif

--- a/src/ppm.cpp
+++ b/src/ppm.cpp
@@ -243,27 +243,6 @@ void PPM::print_configuration() const
 }
 
 bool PPM::configure() {
-
-    if ( optIsSet('v') ) {
-        if ( "TRACE" == optString('v') ) {
-            logger->set_level( spdlog::level::trace );
-        } else if ( "DEBUG" == optString('v') ) {
-            logger->set_level( spdlog::level::debug );
-        } else if ( "INFO" == optString('v') ) {
-            logger->set_level( spdlog::level::info );
-        } else if ( "WARNING" == optString('v') ) {
-            logger->set_level( spdlog::level::warn );
-        } else if ( "ERROR" == optString('v') ) {
-            logger->set_level( spdlog::level::err );
-        } else if ( "CRITICAL" == optString('v') ) {
-            logger->set_level( spdlog::level::critical );
-        } else if ( "OFF" == optString('v') ) {
-            logger->set_level( spdlog::level::off );
-        } else {
-            logger->warn("information logger level was configured but unreadable; using default.");
-        }
-    } // else it is already set to default.
-
     logger->trace("starting configure()");
 
     std::string line;
@@ -855,7 +834,6 @@ int main( int argc, char* argv[] )
     ppm.addOption('x', "exit", "Exit consumer when last message in partition has been received.", false);
     ppm.addOption('d', "debug", "debug level.", true);
     ppm.addOption('m', "mapfile", "Map data file to specify the geofence.", true);
-    ppm.addOption('v', "log-level", "The info log level [trace,debug,info,warning,error,critical,off]", true);
     ppm.addOption('D', "log-dir", "Directory for the log files.", true);
     ppm.addOption('R', "log-rm", "Remove specified/default log files if they exist.", false);
     ppm.addOption('i', "log", "Log file name.", true);

--- a/src/ppmLogger.cpp
+++ b/src/ppmLogger.cpp
@@ -13,7 +13,27 @@ PpmLogger::PpmLogger(std::string logname) {
         sinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_mt>());
     }
     setLogger(std::make_shared<spdlog::logger>("log", begin(sinks), end(sinks)));
+
+    // use PPM_LOG_LEVEL environment variable to set the log level
+    std::string logLevelString = getEnvironmentVariable("PPM_LOG_LEVEL");
+    std::string lowercaseLogLevelString = toLowercase(logLevelString);
+    if (lowercaseLogLevelString == "trace") {
+        loglevel = spdlog::level::trace;
+    } else if (lowercaseLogLevelString == "debug") {
+        loglevel = spdlog::level::debug;
+    } else if (lowercaseLogLevelString == "info") {
+        loglevel = spdlog::level::info;
+    } else if (lowercaseLogLevelString == "warn") {
+        loglevel = spdlog::level::warn;
+    } else if (lowercaseLogLevelString == "error") {
+        loglevel = spdlog::level::err;
+    } else if (lowercaseLogLevelString == "critical") {
+        loglevel = spdlog::level::critical;
+    } else {
+        std::cout << "WARNING: PPM_LOG_LEVEL is not set to a valid value. Using default." << std::endl;
+    }
     set_level( loglevel );
+    
     set_pattern("[%C%m%d %H:%M:%S.%f] [%l] %v");
 }
 

--- a/src/ppmLogger.cpp
+++ b/src/ppmLogger.cpp
@@ -1,10 +1,8 @@
 #include "ppmLogger.hpp"
 
 PpmLogger::PpmLogger(std::string logname) {
-    // pull in the file & console flags from the environment
     initializeFlagValuesFromEnvironment();
     
-    // setup logger.
     std::vector<spdlog::sink_ptr> sinks;
     if (logToFileFlag) {
         sinks.push_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>(logname, LOG_SIZE, LOG_NUM));
@@ -14,26 +12,7 @@ PpmLogger::PpmLogger(std::string logname) {
     }
     setLogger(std::make_shared<spdlog::logger>("log", begin(sinks), end(sinks)));
 
-    // use PPM_LOG_LEVEL environment variable to set the log level
-    std::string logLevelString = getEnvironmentVariable("PPM_LOG_LEVEL");
-    std::string lowercaseLogLevelString = toLowercase(logLevelString);
-    if (lowercaseLogLevelString == "trace") {
-        loglevel = spdlog::level::trace;
-    } else if (lowercaseLogLevelString == "debug") {
-        loglevel = spdlog::level::debug;
-    } else if (lowercaseLogLevelString == "info") {
-        loglevel = spdlog::level::info;
-    } else if (lowercaseLogLevelString == "warn") {
-        loglevel = spdlog::level::warn;
-    } else if (lowercaseLogLevelString == "error") {
-        loglevel = spdlog::level::err;
-    } else if (lowercaseLogLevelString == "critical") {
-        loglevel = spdlog::level::critical;
-    } else {
-        std::cout << "WARNING: PPM_LOG_LEVEL is not set to a valid value. Using default." << std::endl;
-    }
-    set_level( loglevel );
-    
+    setLogLevelFromEnvironment();
     set_pattern("[%C%m%d %H:%M:%S.%f] [%l] %v");
 }
 
@@ -84,6 +63,51 @@ void PpmLogger::initializeFlagValuesFromEnvironment() {
     }
 }
 
+/**
+ * @brief Sets the log level based on the PPM_LOG_LEVEL environment variable.
+ * The log level is set to the default in the following cases:
+ * - PPM_LOG_LEVEL is not set
+ * - PPM_LOG_LEVEL is set to an unrecognized value (including empty string or number)
+ */
+void PpmLogger::setLogLevelFromEnvironment() {
+    std::string logLevelString = getEnvironmentVariable("PPM_LOG_LEVEL");
+    if (logLevelString == "") {
+        std::cout << "WARNING: PPM_LOG_LEVEL is not set. Using default: " << getCurrentLogLevelAsString() << std::endl;
+        return;
+    }
+    
+    std::string lowercaseLogLevelString = toLowercase(logLevelString);
+    if (lowercaseLogLevelString == "trace") {
+        loglevel = spdlog::level::trace;
+    }
+    else if (lowercaseLogLevelString == "debug") {
+        loglevel = spdlog::level::debug;
+    }
+    else if (lowercaseLogLevelString == "info") {
+        loglevel = spdlog::level::info;
+    }
+    else if (lowercaseLogLevelString == "warn") {
+        loglevel = spdlog::level::warn;
+    }
+    else if (lowercaseLogLevelString == "error") {
+        loglevel = spdlog::level::err;
+    }
+    else if (lowercaseLogLevelString == "critical") {
+        loglevel = spdlog::level::critical;
+    }
+    else {
+        std::cout << "WARNING: PPM_LOG_LEVEL is set but is not recognized. Using default: " << getCurrentLogLevelAsString() << std::endl;
+    }
+    set_level( loglevel );
+    info("Log level set to " + getCurrentLogLevelAsString());
+}
+
+/**
+ * @brief Retrieves the value of an environment variable.
+ * 
+ * @param variableName The name of the environment variable to retrieve.
+ * @return const char* The value of the environment variable or an empty string if the variable is not set.
+ */
 const char* PpmLogger::getEnvironmentVariable(std::string variableName) {
     char* variableValue = getenv(variableName.c_str());
     if (variableValue == NULL) {
@@ -109,4 +133,30 @@ bool PpmLogger::convertStringToBool(std::string value) {
         return true;
     }
     return false;
+}
+
+std::string PpmLogger::getCurrentLogLevelAsString() {
+    std::string toReturn = "";
+    if (loglevel == spdlog::level::trace) {
+        toReturn = "TRACE";
+    }
+    else if (loglevel == spdlog::level::debug) {
+        toReturn = "DEBUG";
+    }
+    else if (loglevel == spdlog::level::info) {
+        toReturn = "INFO";
+    }
+    else if (loglevel == spdlog::level::warn) {
+        toReturn = "WARN";
+    }
+    else if (loglevel == spdlog::level::err) {
+        toReturn = "ERROR";
+    }
+    else if (loglevel == spdlog::level::critical) {
+        toReturn = "CRITICAL";
+    }
+    else {
+        toReturn = "UNKNOWN";
+    }
+    return toReturn;
 }

--- a/test-scripts/standalone.sh
+++ b/test-scripts/standalone.sh
@@ -34,7 +34,7 @@ startPPMContainer() {
         fi
     done
     echo "Starting PPM in new container '$PPM_CONTAINER_NAME'"
-    docker run --name $PPM_CONTAINER_NAME --env DOCKER_HOST_IP=$dockerHostIp --env PPM_LOG_TO_CONSOLE=true --env PPM_LOG_TO_FILE=true -v /tmp/docker-test/data:/ppm_data -d -p '8080:8080' $PPM_IMAGE_NAME:$PPM_IMAGE_TAG /cvdi-stream/docker-test/ppm_standalone.sh
+    docker run --name $PPM_CONTAINER_NAME --env DOCKER_HOST_IP=$dockerHostIp --env PPM_LOG_TO_CONSOLE=true --env PPM_LOG_TO_FILE=true --env PPM_LOG_LEVEL=DEBUG -v /tmp/docker-test/data:/ppm_data -d -p '8080:8080' $PPM_IMAGE_NAME:$PPM_IMAGE_TAG /cvdi-stream/docker-test/ppm_standalone.sh
 
     echo "Waiting for $PPM_CONTAINER_NAME to spin up"
     # while num lines of docker logs is less than 100, sleep 1

--- a/test-scripts/standalone_multi.sh
+++ b/test-scripts/standalone_multi.sh
@@ -34,7 +34,7 @@ startPPMContainer() {
         fi
     done
     echo "Starting PPM in new container"
-    docker run --name $PPM_CONTAINER_NAME --env DOCKER_HOST_IP=$dockerHostIp --env PPM_LOG_TO_CONSOLE=true --env PPM_LOG_TO_FILE=true -v $data_source:/ppm_data -d -p $ppm_container_port':8080' $PPM_IMAGE_NAME:$PPM_IMAGE_TAG /cvdi-stream/docker-test/ppm_standalone.sh
+    docker run --name $PPM_CONTAINER_NAME --env DOCKER_HOST_IP=$dockerHostIp --env PPM_LOG_TO_CONSOLE=true --env PPM_LOG_TO_FILE=true --env PPM_LOG_LEVEL=DEBUG -v $data_source:/ppm_data -d -p $ppm_container_port':8080' $PPM_IMAGE_NAME:$PPM_IMAGE_TAG /cvdi-stream/docker-test/ppm_standalone.sh
 
     echo "Waiting for $PPM_CONTAINER_NAME to spin up"
     # while num lines of docker logs is less than 100, sleep 1


### PR DESCRIPTION
# Changes
## Modification in Use of PPM_LOG_LEVEL env var
Previously, the ppm_no_map.sh script referenced the PPM_LOG_LEVEL environment variable and used it to pass the 'v' opt string to the program. This 'v' opt string was then parsed in the 'PPM' class.

With these updates, the PpmLogger now directly accesses the PPM_LOG_LEVEL environment variable, eliminating the necessity for the 'v' opt string.

## Manual Setting of PPM_LOG_LEVEL Environment Variable When Running the PPM Container via Scripts
The PPM_LOG_LEVEL has been adjusted to DEBUG in the standalone.sh and standalone_multi.sh scripts.

This adjustment prevents potential stalling issues during the PPM container's readiness checks, which have affected the execution of the `do_kafka_test.sh` script.

It should be noted that this will not affect the default logging level during regular PPM operation.

# Relevant PR Comment
These changes address the following USDOT PR comment:
https://github.com/usdot-jpo-ode/jpo-cvdp/pull/31#discussion_r1370553964