### PR TITLE
Update do_kafka_test to set DOCKER_HOST_IP

### DIFF
--- a/do_kafka_test.sh
+++ b/do_kafka_test.sh
@@ -24,8 +24,14 @@ PPM_IMAGE_NAME=jpo-cvdp_ppm
 setup() {
     if [ -z $DOCKER_HOST_IP ]
     then
-        export DOCKER_HOST_IP=$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | grep -v '10.*' | head -n 1)
+        export DOCKER_HOST_IP=$(ifconfig | grep -A 1 'inet ' | grep -v 'inet6\|127.0.0.1' | awk '{print $2}' | grep -E '^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.' | head -n 1)
     fi
+    if [ -z $DOCKER_HOST_IP ]
+    then
+        echo "DOCKER_HOST_IP is not set and could not be determined. Exiting."
+        exit 1
+    fi
+
 
     # print setup info
     echo "=== Setup Info ==="

--- a/do_kafka_test.sh
+++ b/do_kafka_test.sh
@@ -22,9 +22,9 @@ PPM_IMAGE_TAG=do-kafka-test-ppm-image
 PPM_IMAGE_NAME=jpo-cvdp_ppm
 
 setup() {
-    if [ -z $DOCKER_HOST_IP ]; then
-        echo "DOCKER_HOST_IP is not set. Exiting."
-        exit 1
+    if [ -z $DOCKER_HOST_IP ]
+    then
+        export DOCKER_HOST_IP=$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | grep -v '10.*' | head -n 1)
     fi
 
     # print setup info


### PR DESCRIPTION
Update the do_kafka_test script to automatically determine DOCKER_HOST_IP in the case that it is not set instead of automatically exiting