### PR TITLE
Removed docker CI actions & reduced installation duplication in dockerfiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,6 @@ jobs:
          cmake --build _cmake_build --target install  
      - name: Install sonar-scanner and build-wrapper
        uses: sonarsource/sonarcloud-github-c-cpp@v2  # This Action Installs sonar cloud and build wrapper to run sonar scan analysis  
-     - name: Set up Docker Buildx
-       uses: docker/setup-buildx-action@v3
-     - name: Build
-       uses: docker/build-push-action@v5
      - name: Build and Generate test coverage
        run: |
          cd $GITHUB_WORKSPACE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,31 @@
+# === RUNTIME DEPENDENCIES IMAGE ===
+FROM alpine:3.12 as runtime-deps
+USER root
+
+WORKDIR /cvdi-stream
+
+# update the package manager
+RUN apk update
+
+# add runtime dependencies
+RUN apk add --upgrade --no-cache \
+    bash \
+    librdkafka \
+    librdkafka-dev
+
 # === BUILDER IMAGE ===
-FROM alpine:3.12 as builder
+FROM runtime-deps as builder
 USER root
 
 WORKDIR /cvdi-stream
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# update the package manager
-RUN apk update
-
 # add build dependencies
 RUN apk add --upgrade --no-cache --virtual .build-deps \
     cmake \
     g++ \
-    make \
-    librdkafka \
-    librdkafka-dev
+    make
 
 # add the source and build files
 ADD CMakeLists.txt /cvdi-stream
@@ -30,16 +40,10 @@ ADD ./config /cvdi-stream/config
 RUN export LD_LIBRARY_PATH=/usr/local/lib && mkdir /cvdi-stream-build && cd /cvdi-stream-build && cmake /cvdi-stream && make
 
 # === RUNTIME IMAGE ===
-FROM alpine:3.12
+FROM runtime-deps
 USER root
 
 WORKDIR /cvdi-stream
-
-# add runtime dependencies
-RUN apk add --upgrade --no-cache \
-    bash \
-    librdkafka \
-    librdkafka-dev
 
 # copy the built files from the builder
 COPY --from=builder /cvdi-stream-build/ /cvdi-stream-build/

--- a/Dockerfile-nsv
+++ b/Dockerfile-nsv
@@ -1,5 +1,20 @@
+# === RUNTIME DEPENDENCIES IMAGE ===
+FROM alpine:3.12 as runtime-deps
+USER root
+
+WORKDIR /cvdi-stream
+
+# update the package manager
+RUN apk update
+
+# add runtime dependencies
+RUN apk add --upgrade --no-cache \
+    bash \
+    librdkafka \
+    librdkafka-dev
+
 # === BUILDER IMAGE ===
-FROM alpine:3.12 as builder
+FROM runtime-deps as builder
 USER root
 ARG PPM_CONFIG_FILE
 ARG PPM_MAP_FILE
@@ -8,16 +23,11 @@ WORKDIR /cvdi-stream
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# update the package manager
-RUN apk update
-
 # add build dependencies
 RUN apk add --upgrade --no-cache --virtual .build-deps \
     cmake \
     g++ \
-    make \
-    librdkafka \
-    librdkafka-dev
+    make
 
 # add the source and build files
 ADD CMakeLists.txt /cvdi-stream
@@ -34,16 +44,10 @@ ADD ./config /cvdi-stream/config
 RUN export LD_LIBRARY_PATH=/usr/local/lib && mkdir /cvdi-stream-build && cd /cvdi-stream-build && cmake /cvdi-stream && make
 
 # === RUNTIME IMAGE ===
-FROM alpine:3.12
+FROM runtime-deps
 USER root
 
 WORKDIR /cvdi-stream
-
-# add runtime dependencies
-RUN apk add --upgrade --no-cache \
-    bash \
-    librdkafka \
-    librdkafka-dev
 
 # copy the built files from the builder
 COPY --from=builder /cvdi-stream-build/ /cvdi-stream-build/

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -1,21 +1,31 @@
+# === RUNTIME DEPENDENCIES IMAGE ===
+FROM alpine:3.12 as runtime-deps
+USER root
+
+WORKDIR /cvdi-stream
+
+# update the package manager
+RUN apk update
+
+# add runtime dependencies
+RUN apk add --upgrade --no-cache \
+    bash \
+    librdkafka \
+    librdkafka-dev
+
 # === BUILDER IMAGE ===
-FROM alpine:3.12 as builder
+FROM runtime-deps as builder
 USER root
 
 WORKDIR /cvdi-stream
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# update the package manager
-RUN apk update
-
 # add build dependencies
 RUN apk add --upgrade --no-cache --virtual .build-deps \
     cmake \
     g++ \
-    make \
-    librdkafka \
-    librdkafka-dev
+    make
 
 # add the source and build files
 ADD CMakeLists.txt /cvdi-stream
@@ -30,16 +40,10 @@ ADD ./config /cvdi-stream/config
 RUN export LD_LIBRARY_PATH=/usr/local/lib && mkdir /cvdi-stream-build && cd /cvdi-stream-build && cmake /cvdi-stream && make
 
 # === RUNTIME IMAGE ===
-FROM alpine:3.12
+FROM runtime-deps
 USER root
 
 WORKDIR /cvdi-stream
-
-# add runtime dependencies
-RUN apk add --upgrade --no-cache \
-    bash \
-    librdkafka \
-    librdkafka-dev
 
 # copy the built files from the builder
 COPY --from=builder /cvdi-stream-build/ /cvdi-stream-build/

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,21 +1,31 @@
+# === RUNTIME DEPENDENCIES IMAGE ===
+FROM alpine:3.12 as runtime-deps
+USER root
+
+WORKDIR /cvdi-stream
+
+# update the package manager
+RUN apk update
+
+# add runtime dependencies
+RUN apk add --upgrade --no-cache \
+    bash \
+    librdkafka \
+    librdkafka-dev
+
 # === BUILDER IMAGE ===
-FROM alpine:3.12 as builder
+FROM runtime-deps as builder
 USER root
 
 WORKDIR /cvdi-stream
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# update the package manager
-RUN apk update
-
 # add build dependencies
 RUN apk add --upgrade --no-cache --virtual .build-deps \
     cmake \
     g++ \
-    make \
-    librdkafka \
-    librdkafka-dev
+    make
 
 # add the source and build files
 ADD CMakeLists.txt /cvdi-stream
@@ -30,17 +40,10 @@ ADD ./config /cvdi-stream/config
 RUN export LD_LIBRARY_PATH=/usr/local/lib && mkdir /cvdi-stream-build && cd /cvdi-stream-build && cmake /cvdi-stream && make
 
 # === RUNTIME IMAGE ===
-FROM alpine:3.12
+FROM runtime-deps
 USER root
 
 WORKDIR /cvdi-stream
-
-# add runtime dependencies
-RUN apk add --upgrade --no-cache \
-    bash \
-    python3 \
-    librdkafka \
-    librdkafka-dev
 
 # copy the built files from the builder
 COPY --from=builder /cvdi-stream-build/ /cvdi-stream-build/

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -10,6 +10,7 @@ RUN apk update
 # add runtime dependencies
 RUN apk add --upgrade --no-cache \
     bash \
+    python3 \
     librdkafka \
     librdkafka-dev
 


### PR DESCRIPTION
## Problem
Dan has requested (on https://github.com/usdot-jpo-ode/jpo-cvdp/pull/37) that we remove a couple of docker CI actions & was wondering whether we could copy packages from the builder to the runtime image to avoid duplicating package installation.

## Solution
The docker setup & build/push actions have been removed from the `ci.yml` file.

Additionally, the dockerfiles have been modified to first define an image with runtime dependencies, which is used as the base image for the builder & runtime images.

## Testing
- The program has been spun up using docker-compose successfully. The --build flag was used to ensure the new dockerfile contents were used.
- The `do_kafka_test.sh` script executed successfully.