### PR TITLE
Modified dev container to make all scripts executable upon creation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,8 +23,8 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "gcc -v",
+	"postCreateCommand": "sudo find /workspaces/ -type f -iname \"*.sh\" -exec chmod +x {} \\;" // Make all shell scripts executable
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	// "remoteUser": "vscode"
 }


### PR DESCRIPTION
## Problem
Upon the creation of the dev container, there's no guarantee that the shell scripts will have executable permissions. This likely depends on the permissions of the file prior to getting mounted into the dev container.

## Solution
The dev container configuration has been modified to run a command post-creation to make all shell scripts executable.

## USDOT PR
This addresses a comment on https://github.com/usdot-jpo-ode/jpo-cvdp/pull/41