### PR TITLE
Removed unnecessary 'version' element from docker-compose files

### DIFF
--- a/docker-compose-confluent-cloud.yml
+++ b/docker-compose-confluent-cloud.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   ppm:
     build:

--- a/docker-compose-kafka.yml
+++ b/docker-compose-kafka.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   zookeeper:
     image: wurstmeister/zookeeper

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   zookeeper:
     image: wurstmeister/zookeeper


### PR DESCRIPTION
## Problem
The 'version' element is obsolete and no longer necessary. See https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-and-name-top-level-elements

When using docker compose, the user receives a warning about this and this can be confusing.

## Solution
The 'version' element has been removed from the docker-compose files.

## USDOT PR
This addresses a comment on https://github.com/usdot-jpo-ode/jpo-cvdp/pull/41