### PR TITLE
Updated `Release_notes.md` for 2025 Q1 release

### DIFF
--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -7,8 +7,8 @@ Version 1.5.0, released January 2025
 The jpo-cvdp 1.5.0 release includes an enhancement to redact the "asn1" field from BSM messages, ensuring that filtered BSM messages no longer contain the field. Additionally, it updates GitHub Actions workflows with the latest versions of third-party actions from external repositories to eliminate Node.js and other deprecation warnings.
 
 Enhancements in this release:
-- CDOT PR 54: BSM "asn1" Field Redaction
-- USDOT PR 45: Update GitHub Actions Third-Party Action Versions
+- [CDOT PR 54](https://github.com/CDOT-CV/jpo-cvdp/pull/54): BSM "asn1" Field Redaction
+- [USDOT PR 45](https://github.com/usdot-jpo-ode/jpo-cvdp/pull/45): Update GitHub Actions Third-Party Action Versions
 
 Known Issues:
 - No known issues at this time.

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -1,6 +1,19 @@
 Jpo-cvdp Release Notes
 ----------------------------
 
+Version 1.5.0, released January 2025
+----------------------------------------
+### **Summary**
+The jpo-cvdp 1.5.0 release includes an enhancement to redact the "asn1" field from BSM messages, ensuring that filtered BSM messages no longer contain the field. Additionally, it updates GitHub Actions workflows with the latest versions of third-party actions from external repositories to eliminate Node.js and other deprecation warnings.
+
+Enhancements in this release:
+- CDOT PR 54: BSM "asn1" Field Redaction
+- USDOT PR 45: Update GitHub Actions Third-Party Action Versions
+
+Known Issues:
+- No known issues at this time.
+
+
 Version 1.4.0, released September 2024
 ----------------------------------------
 ### **Summary**


### PR DESCRIPTION
## Problem
A new version of jpo-cvdp will be released this month, but the release notes need to be updated.

## Solution
The release notes have been updated to include all CDOT changes for this quarter, along with planned USDOT changes.